### PR TITLE
get_packages: Use tetaneutral mirror

### DIFF
--- a/get_packages.sh
+++ b/get_packages.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 
-FDROID_REPO_URL="https://f-droid.org/repo"
+FDROID_REPO_URL="https://fdroid.tetaneutral.net/fdroid/repo/"
 
 ###########################################################
 


### PR DESCRIPTION
Reduce F-Droid.org load with using tetaneutral mirror. 